### PR TITLE
Add missing link to Python Packaging User Guide

### DIFF
--- a/warehouse/templates/includes/accounts/profile-callout.html
+++ b/warehouse/templates/includes/accounts/profile-callout.html
@@ -14,7 +14,7 @@
 
 <div class="callout-block no-top-margin">
   {% if user.id == request.user.id %}
-  <p>You have not uploaded any projects to PyPI, yet. To learn how to get started, visit the <a href="">Python Packaging User Guide</a></p>
+  <p>You have not uploaded any projects to PyPI, yet. To learn how to get started, visit the <a href="https://packaging.python.org/">Python Packaging User Guide</a></p>
   {% else %}
   <p>{{ user.name|default(user.username, true) }} has not uploaded any projects to PyPI, yet.</p>
   {% endif %}


### PR DESCRIPTION
I just registered a new account on PyPI and got this message.

![get_started](https://user-images.githubusercontent.com/24502053/28254976-26bf82ac-6a6f-11e7-8e54-29a64340b8a9.png)

I tried to click the link for `"Python Packaging User Guide"` but it wouldn't work. I couldn't find any issues about this so I made this PR which adds the link to the html.
